### PR TITLE
Add return type in getConfigTreeBuilder

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('rrdbundle');
         


### PR DESCRIPTION
Deprecation: Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "JimmyCleuren\Bundle\RrdBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.